### PR TITLE
在spm@3.6.0版本下执行spm build失败

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
       "sinon" : "1.6.0",
       "jquery" : "1.9.1"
     },
+    "build": {
+      "global": {
+        "eve": "eve"
+      }
+    },
     "engines": {
       "seajs": "2.2.1"
     },


### PR DESCRIPTION
在spm@3.6.0版本下执行spm build失败，需要把eve添加成global，这样spm才不会把它当成AMD的来解析。
